### PR TITLE
Make quoted content the same size as new post content.

### DIFF
--- a/www/themes/ltb/css/layout.css
+++ b/www/themes/ltb/css/layout.css
@@ -978,6 +978,9 @@ box-shadow:         0px 1px 5px 0px rgba(50, 50, 50, 0.5);
 	vertical-align: top;
 	font-size: 12px;
 }
+.post-content blockquote p {
+	font-size: 12px;
+}
 .forum-stats{
 	
 }


### PR DESCRIPTION
I always get confused and think the previous, quoted content is newer because it is bigger.  This simple CSS fix makes the quoted content the same size and in my opinion improves the user experience just a little bit.

Before: http://i.imgur.com/aca007f.png

After: http://i.imgur.com/5aXgLNk.png
