### PR TITLE
Added consistent preview size for markdown preview quotes

### DIFF
--- a/www/themes/ltb/css/layout.css
+++ b/www/themes/ltb/css/layout.css
@@ -981,6 +981,9 @@ box-shadow:         0px 1px 5px 0px rgba(50, 50, 50, 0.5);
 .post-content blockquote p {
 	font-size: 12px;
 }
+.markdown-preview blockquote p {
+	font-size: 12px;
+}
 .forum-stats{
 	
 }


### PR DESCRIPTION
This is an amendment to my quote size fix.  This needs to be in the markdown-preview as well.
