### PR TITLE
Removed unused SQL statements

### DIFF
--- a/www/slick/App/API/V1/Blog/Model.php
+++ b/www/slick/App/API/V1/Blog/Model.php
@@ -216,8 +216,6 @@ class Slick_App_API_V1_Blog_Model extends Slick_App_Forum_Board_Model
 			
 			$sql = 'SELECT '.$getPostFields.'
 					 FROM blog_posts p
-					 LEFT JOIN blog_postMeta mv ON mv.postId = p.postId
-					 LEFT JOIN blog_postMetaTypes mt ON mt.metaTypeId = mv.metaTypeId
 					 WHERE '.$andSites.'
 					 AND p.published = 1
 					 AND p.publishDate <= "'.timestamp().'"


### PR DESCRIPTION
I'm almost certain these statements have absolutely no effect on the results of the query.

After removing these, try putting the sort back to `p.publishDate DESC` and adding an index on p.publishDate.  I think you need an index on p.publishDate either way since it is part of your query.
