### PR TITLE
No such field exists at this position

### DIFF
--- a/www/slick/App/API/V1/Forum/README.md
+++ b/www/slick/App/API/V1/Forum/README.md
@@ -228,8 +228,6 @@
 			* postTime (timestamp)
 			* editTime (timestamp)
 			* editedBy (int)
-			* author (array)
-				* see previous author field for reference.
 * **/threads/{ID}/{REPLYID} (get single reply)**
 	* **METHOD:** GET
 	* **Params:**


### PR DESCRIPTION
And it would be confusing if it did (i.e. how could a single reply possibly have multiple authors?).